### PR TITLE
Weather serializer refactor

### DIFF
--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,18 +1,8 @@
 class Api::V1::ForecastController < ApplicationController
 
   def index
-    weather_data = DarkSkyService.new(location.latitude, location.longitude).full_info
-    render json: WeatherDataSerializer.new(weather_data, location).to_hash
+    weather_data = WeatherData.new(params[:location])
+    render json: WeatherDataSerializer.new(weather_data)
   end
-
-  private
-
-  def location
-    @_city ||= Cities.find_or_create_city(params[:location])
-    @_city.find_or_create_background
-    return @_city
-  end
-
-
 
 end

--- a/app/models/cities.rb
+++ b/app/models/cities.rb
@@ -17,7 +17,7 @@ class Cities < ApplicationRecord
                     longitude: city_info.long,
                     name: city_info.details[0][:short_name],
                     state_abrev: city_info.details[2][:short_name],
-                    country: city_info.details[3][:short_name])
+                    country: city_info.details[3][:long_name])
     end
   end
 

--- a/app/models/weather_data.rb
+++ b/app/models/weather_data.rb
@@ -1,0 +1,61 @@
+class WeatherData
+
+  def initialize(search_info)
+    @search_info = search_info
+  end
+
+  def location
+    @_city ||= Cities.find_or_create_city(@search_info)
+    @_city.find_or_create_background
+    return @_city
+  end
+
+  def api_weather_data
+    @_data ||= DarkSkyService.new(location.latitude, location.longitude).full_info
+  end
+
+  def currently
+    api_weather_data[:currently]
+  end
+
+  def today
+    api_weather_data[:daily][:data][0]
+  end
+
+  def hourly
+    api_weather_data[:hourly][:data][1..8]
+  end
+
+  def daily
+   api_weather_data[:daily][:data][1..5]
+  end
+
+  def hourly_formatted
+    hourly.map do |hour|
+      hour_hash = {}
+      hour.each do |key, value|
+        hour_hash[:time] = hour[:time]
+        hour_hash[:hour] = Time.at(hour[:time]).strftime("%l%p")
+        hour_hash[:temp] = hour[:temperature].round
+      end
+      hour_hash
+    end
+  end
+
+  def rest_of_week_formatted
+    daily.map do |day|
+      daily_hash = {}
+      day.each do |key, value|
+        daily_hash[:date] = day[:time]
+        daily_hash[:day] = Time.at(day[:time]).strftime("%A")
+        daily_hash[:icon] = day[:icon]
+        daily_hash[:chance_precip] = "#{(day[:precipProbability] * 100).round}%"
+        daily_hash[:precip_type] = day[:precipType]
+        daily_hash[:high] = day[:temperatureHigh].round
+        daily_hash[:low] = day[:temperatureLow].round
+      end
+      daily_hash
+    end
+  end
+
+end

--- a/app/serializers/weather_data_serializer.rb
+++ b/app/serializers/weather_data_serializer.rb
@@ -1,11 +1,11 @@
 class WeatherDataSerializer
 
-  def initialize(weather_data, location)
-    @location = location
-    @currently = weather_data[:currently]
-    @today = weather_data[:daily][:data][0]
-    @hourly = weather_data[:hourly][:data][1..8]
-    @rest_of_week = weather_data[:daily][:data][1..5]
+  def initialize(weather_data)
+    @location = weather_data.location
+    @currently = weather_data.currently
+    @today = weather_data.today
+    @hourly = weather_data.hourly_formatted
+    @rest_of_week = weather_data.rest_of_week_formatted
   end
 
   def to_hash
@@ -20,7 +20,9 @@ class WeatherDataSerializer
           city_state: "#{@location.name}, #{@location.state_abrev}",
           country: @location.country,
           search_time: Time.at(@currently[:time]).strftime("%l:%M %p"),
-          date: Time.at(@currently[:time]).strftime("%m/%d")
+          date: Time.at(@currently[:time]).strftime("%m/%d"),
+          latitude: @location.latitude,
+          longitude: @location.longitude
         },
         details: {
           icon: @currently[:icon],
@@ -32,38 +34,11 @@ class WeatherDataSerializer
           summary: @today[:summary],
         },
         forecast: {
-          hourly: hourly_formatted(@hourly),
-          extended: rest_of_week_formatted(@rest_of_week)
+          hourly: @hourly,
+          extended: @rest_of_week
         }
       }
     }
   end
 
-  private
-
-  def hourly_formatted(hourly)
-    hourly.map do |hour|
-      hour_hash = {}
-      hour.each do |key, value|
-        hour_hash[:hour] = Time.at(hour[:time]).strftime("%l%p")
-        hour_hash[:temp] = hour[:temperature].round
-      end
-      hour_hash
-    end
-  end
-
-  def rest_of_week_formatted(rest_of_week)
-    rest_of_week.map do |day|
-      daily_hash = {}
-      day.each do |key, value|
-        daily_hash[:date] = Time.at(day[:time]).strftime("%A")
-        daily_hash[:icon] = day[:icon]
-        daily_hash[:chance_precip] = "#{(day[:precipProbability] * 100).round}%"
-        daily_hash[:precip_type] = day[:precipType]
-        daily_hash[:high] = day[:temperatureHigh].round
-        daily_hash[:low] = day[:temperatureLow].round
-      end
-      daily_hash
-    end
-  end
 end

--- a/app/services/dark_sky_service.rb
+++ b/app/services/dark_sky_service.rb
@@ -9,16 +9,6 @@ class DarkSkyService
     get_json
   end
 
-# potential additional sorting methods
-  # def current_overview
-  # end
-  #
-  # def current_details
-  # end
-  #
-  # def forecast
-  # end
-
   private
 
   def get_json

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,5 +8,5 @@
 Cities.destroy_all
 
 cities = Cities.create(
-  {search_name: "denver,co", latitude: 39.7392, longitude: 104.9902, name:"Denver", state_abrev: "CO", country: "United States" }
+  {search_name: "denver,co", latitude: 39.7392, longitude: -104.9902, name:"Denver", state_abrev: "CO", country: "United States" }
 )


### PR DESCRIPTION
- Creates WeatherData PORO for formatting API information, which is then passed in as a single object to the WeatherDataSerializer, which then renders as JSON from Forecast#Index.
- Refactors previous WeatherDataSerializer, moving sorting logic to the WeatherData PORO.
- Fixes Cities #country, using correct key (:long_name). Fixes :longitude for Denver seed file. More cities to be added - potentially ran as a rake task, or something similar from the seed file.