### PR TITLE
Adds destroy action to FavoritesController, along with route and spec.

### DIFF
--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -11,6 +11,12 @@ class Api::V1::FavoritesController < ActionController::API
       render json: FavoritesSerializer.new(user.favorites).to_hash
     end
 
+    def destroy
+      to_remove = user.favorites.find_by(cities_id: favorite_to_remove.id)
+      to_remove.destroy
+      render json: FavoritesSerializer.new(user.favorites).to_hash
+    end
+
     private
 
     def search_location
@@ -19,6 +25,17 @@ class Api::V1::FavoritesController < ActionController::API
     end
 
     def favorite_params
+      params.permit(:location, :api_key)
+    end
+
+    def favorite_to_remove
+      split = destroy_params[:location].split(",")
+      city_input = split[0]
+      state_input = split[1].delete(" ")
+      city = Cities.find_by(name: city_input, state_abrev: state_input)
+    end
+
+    def destroy_params
       params.permit(:location, :api_key)
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
 
       get '/favorites', to: 'favorites#index'
       post '/favorites', to: 'favorites#create'
+      delete '/favorites', to: 'favorites#destroy'
 
       get '/forecast', to: 'forecast#show'
 

--- a/spec/requests/api/v1/favorites/remove_favorite_spec.rb
+++ b/spec/requests/api/v1/favorites/remove_favorite_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe 'DELETE /api/v1/favorites' do
+  context 'with a valid api key' do
+    it 'removes a city from the list of favorites' do
+      user = create(:user, api_key: "abc123")
+
+      denver = Cities.find_or_create_city("denver,co")
+      golden = Cities.find_or_create_city("golden,co")
+
+      user.favorites.create(cities_id: denver.id)
+      user.favorites.create(cities_id: golden.id)
+
+      expect(user.favorites.count).to eq(2)
+
+      delete_body = {
+        "location": "Denver, CO", # If you decide to store cities in your database you can send an id if you prefer
+        "api_key": "abc123"
+      }
+
+      delete '/api/v1/favorites', params: delete_body
+
+      delete_response = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response.status).to eq(200)
+      expect(delete_response.count).to eq(1)
+      expect(delete_response[0][:location]).to eq("Golden, CO")
+
+      expect(user.favorites.count).to eq(1)
+    end
+  end
+
+  context 'with an invalid api key' do
+    it 'does not remove a city from the favorites, and a 401 code is returned' do
+      user = create(:user, api_key: "abc123")
+
+      denver = Cities.find_or_create_city("denver,co")
+      golden = Cities.find_or_create_city("golden,co")
+
+      user.favorites.create(cities_id: denver.id)
+      user.favorites.create(cities_id: golden.id)
+
+      expect(user.favorites.count).to eq(2)
+
+      delete_body = {
+        "location": "Denver, CO", # If you decide to store cities in your database you can send an id if you prefer
+        "api_key": "xyz123"
+      }
+
+      delete '/api/v1/favorites', params: delete_body
+
+      delete_response = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response.status).to eq(401)
+      expect(delete_response[:invalid]).to eq("Unauthorized")
+
+      expect(user.favorites.count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
A user can remove a favorite with a successful DELETE request to /api/v1/favorites, with a valid API KEY.
- Created Destroy action in FavoritesController
- Includes logic to find cities_id from City/State input.