### PR TITLE
Api key fix

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,5 +1,4 @@
-class Api::V1::UsersController < ApplicationController
-  protect_from_forgery with: :null_session
+class Api::V1::UsersController < ActionController::API
 
   def create
     user = User.new(user_params)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   has_secure_password
 
   def generate_api_key
-    self.api_key = SecureRandom.urlsafe_base64
+    self.update_attributes(api_key: SecureRandom.urlsafe_base64)
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@ Favorite.destroy_all
 Cities.destroy_all
 User.destroy_all
 
-user = User.create(email: 'corey@email.com', password_digest: 'password', api_key: 'abc123')
+user = User.create(email: 'corey@email.com', password: 'password', password_confirmation: 'password', api_key: 'abc123')
 
 cities = Cities.create(
   { search_name: "denver,co", latitude: 39.7392, longitude: -104.9902, name:"Denver", state_abrev: "CO", country: "United States" }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,4 @@
-# require 'rails_helper'
+require 'rails_helper'
 
 describe User, type: :model do
   describe 'Validations' do


### PR DESCRIPTION
Issue: When a user was being created, an API was generates, but not saved to the user. This function has been fixed, and the generated API key is now saved to the user object.

- User #generate_api_key
 `self.update_attributes(api_key: SecureRandom.urlsafe_base64)`