### PR TITLE
Renames Cities model to City - updates necessary places

### DIFF
--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -2,8 +2,8 @@ class Api::V1::FavoritesController < ApiController
   before_action :user
 
   def create
-    city = Cities.find_or_create_city(search_location)
-    Favorite.create(user_id: user.id, cities_id: city.id, name: city.name)
+    city = City.find_or_create_city(search_location)
+    Favorite.create(user_id: user.id, city_id: city.id, name: city.name)
     render status: 201, json: { outcome: "Successfully Added" }
   end
 
@@ -12,7 +12,7 @@ class Api::V1::FavoritesController < ApiController
   end
 
   def destroy
-    to_remove = user.favorites.find_by(cities_id: favorite_to_remove.id)
+    to_remove = user.favorites.find_by(city_id: favorite_to_remove.id)
     to_remove.destroy
     render json: FavoritesSerializer.new(user.favorites).to_hash
   end
@@ -32,7 +32,7 @@ class Api::V1::FavoritesController < ApiController
     split = destroy_params[:location].split(",")
     city_input = split[0]
     state_input = split[1].delete(" ")
-    city = Cities.find_by(name: city_input, state_abrev: state_input)
+    city = City.find_by(name: city_input, state_abrev: state_input)
   end
 
   def destroy_params

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,4 +1,4 @@
-class Cities < ApplicationRecord
+class City < ApplicationRecord
   validates_presence_of :search_name,
                         :latitude,
                         :longitude,
@@ -8,11 +8,11 @@ class Cities < ApplicationRecord
   has_many :favorites
 
   def self.find_or_create_city(location)
-    if Cities.find_by(search_name: location)
-      return Cities.find_by(search_name: location)
+    if City.find_by(search_name: location)
+      return City.find_by(search_name: location)
     else
       city_info = LocationService.new(location)
-      Cities.create(search_name: location,
+      City.create(search_name: location,
                     latitude: city_info.lat,
                     longitude: city_info.long,
                     name: city_info.details[0][:short_name],

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,4 +1,4 @@
 class Favorite < ApplicationRecord
   belongs_to :user
-  belongs_to :cities  
+  belongs_to :city 
 end

--- a/app/models/weather_data.rb
+++ b/app/models/weather_data.rb
@@ -5,7 +5,7 @@ class WeatherData
   end
 
   def location
-    @_city ||= Cities.find_or_create_city(@search_info)
+    @_city ||= City.find_or_create_city(@search_info)
     @_city.find_or_create_background
     return @_city
   end

--- a/app/serializers/favorites_serializer.rb
+++ b/app/serializers/favorites_serializer.rb
@@ -7,8 +7,8 @@ class FavoritesSerializer
   def to_hash
     @favorites.map do |favorite|
       {
-        location: favorite.cities.location,
-        current_weather: current_weather(favorite.cities)
+        location: favorite.city.location,
+        current_weather: current_weather(favorite.city)
       }
     end
   end

--- a/db/migrate/20190601232139_create_cities.rb
+++ b/db/migrate/20190601232139_create_cities.rb
@@ -1,4 +1,4 @@
-class CreateCities < ActiveRecord::Migration[5.2]
+class CreateCity < ActiveRecord::Migration[5.2]
   def change
     create_table :cities do |t|
       t.string :search_name

--- a/db/migrate/20190602172735_add_backgroun_image_column_to_cities.rb
+++ b/db/migrate/20190602172735_add_backgroun_image_column_to_cities.rb
@@ -1,4 +1,4 @@
-class AddBackgrounImageColumnToCities < ActiveRecord::Migration[5.2]
+class AddBackgrounImageColumnToCity < ActiveRecord::Migration[5.2]
   def change
     add_column :cities, :background_img, :string
   end

--- a/db/migrate/20190602173031_change_default_value_to_cities_bkrd_column.rb
+++ b/db/migrate/20190602173031_change_default_value_to_cities_bkrd_column.rb
@@ -1,4 +1,4 @@
-class ChangeDefaultValueToCitiesBkrdColumn < ActiveRecord::Migration[5.2]
+class ChangeDefaultValueToCityBkrdColumn < ActiveRecord::Migration[5.2]
   def change
     change_column :cities, :background_img, :string, default: nil
   end

--- a/db/migrate/20190621212928_change_cities_id_name.rb
+++ b/db/migrate/20190621212928_change_cities_id_name.rb
@@ -1,0 +1,5 @@
+class ChangeCitiesIdName < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :favorites, :cities_id, :city_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_04_163419) do
+ActiveRecord::Schema.define(version: 2019_06_21_212928) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,11 +29,11 @@ ActiveRecord::Schema.define(version: 2019_06_04_163419) do
 
   create_table "favorites", force: :cascade do |t|
     t.bigint "user_id"
-    t.bigint "cities_id"
+    t.bigint "city_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
-    t.index ["cities_id"], name: "index_favorites_on_cities_id"
+    t.index ["city_id"], name: "index_favorites_on_city_id"
     t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
@@ -45,6 +45,6 @@ ActiveRecord::Schema.define(version: 2019_06_04_163419) do
     t.datetime "updated_at", null: false
   end
 
-  add_foreign_key "favorites", "cities", column: "cities_id"
+  add_foreign_key "favorites", "cities"
   add_foreign_key "favorites", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,11 +6,11 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 Favorite.destroy_all
-Cities.destroy_all
+City.destroy_all
 User.destroy_all
 
 user = User.create(email: 'corey@email.com', password: 'password', password_confirmation: 'password', api_key: 'abc123')
 
-cities = Cities.create(
+cities = City.create(
   { search_name: "denver,co", latitude: 39.7392, longitude: -104.9902, name:"Denver", state_abrev: "CO", country: "United States" }
 )

--- a/spec/models/cities_spec.rb
+++ b/spec/models/cities_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Cities, type: :model do
+describe City, type: :model do
   describe 'Validations' do
     it { should validate_presence_of :search_name }
     it { should validate_presence_of :latitude }
@@ -19,17 +19,17 @@ describe Cities, type: :model do
       it 'finds or creates a new city based on search input info' do
         search_name = "denver,co"
 
-        expect(Cities.count).to eq(0)
+        expect(City.count).to eq(0)
 
-        Cities.find_or_create_city(search_name)
+        City.find_or_create_city(search_name)
 
-        expect(Cities.count).to eq(1)
-        expect(Cities.first.name).to eq("Denver")
-        expect(Cities.first.state_abrev).to eq("CO")
+        expect(City.count).to eq(1)
+        expect(City.first.name).to eq("Denver")
+        expect(City.first.state_abrev).to eq("CO")
 
-        Cities.find_or_create_city(search_name)
+        City.find_or_create_city(search_name)
         #finds existing city - no new city is added to table
-        expect(Cities.count).to eq(1)
+        expect(City.count).to eq(1)
       end
     end
   end
@@ -37,7 +37,7 @@ describe Cities, type: :model do
   describe 'Instance Methods' do
     context '#find_or_create_background' do
       it 'finds a background_img for a city if it does not already have one' do
-        denver = Cities.create(
+        denver = City.create(
           { search_name: "denver,co",
             latitude: 39.7392,
             longitude: 104.9902,
@@ -56,7 +56,7 @@ describe Cities, type: :model do
       end
 
       it 'does not creates a background_img for a city which already has one' do
-        denver = Cities.create(
+        denver = City.create(
           { search_name: "denver,co",
             latitude: 39.7392,
             longitude: 104.9902,

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -3,6 +3,6 @@ require 'rails_helper'
 describe Favorite, type: :model do
   describe 'Relationships' do
     it { should belong_to :user }
-    it { should belong_to :cities }
+    it { should belong_to :city }
   end
 end

--- a/spec/requests/api/v1/favorites/list_favorites_spec.rb
+++ b/spec/requests/api/v1/favorites/list_favorites_spec.rb
@@ -5,11 +5,11 @@ describe 'GET /api/v1/favorites' do
     it 'returns a list of favorite locations and current weather info' do
       user = create(:user, api_key: "abc123")
 
-      denver = Cities.find_or_create_city("denver,co")
-      golden = Cities.find_or_create_city("golden,co")
+      denver = City.find_or_create_city("denver,co")
+      golden = City.find_or_create_city("golden,co")
 
-      user.favorites.create(cities_id: denver.id)
-      user.favorites.create(cities_id: golden.id)
+      user.favorites.create(city_id: denver.id)
+      user.favorites.create(city_id: golden.id)
 
       get_body = {
         "api_key": "abc123"
@@ -33,11 +33,11 @@ describe 'GET /api/v1/favorites' do
     it 'no favorites are shown, and a 401 status code is returned' do
       user = create(:user, api_key: "abc123")
 
-      denver = Cities.find_or_create_city("denver,co")
-      golden = Cities.find_or_create_city("golden,co")
+      denver = City.find_or_create_city("denver,co")
+      golden = City.find_or_create_city("golden,co")
 
-      user.favorites.create(cities_id: denver.id)
-      user.favorites.create(cities_id: golden.id)
+      user.favorites.create(city_id: denver.id)
+      user.favorites.create(city_id: golden.id)
 
       get_body = {
         "api_key": "xyz123"

--- a/spec/requests/api/v1/favorites/remove_favorite_spec.rb
+++ b/spec/requests/api/v1/favorites/remove_favorite_spec.rb
@@ -5,11 +5,11 @@ describe 'DELETE /api/v1/favorites' do
     it 'removes a city from the list of favorites' do
       user = create(:user, api_key: "abc123")
 
-      denver = Cities.find_or_create_city("denver,co")
-      golden = Cities.find_or_create_city("golden,co")
+      denver = City.find_or_create_city("denver,co")
+      golden = City.find_or_create_city("golden,co")
 
-      user.favorites.create(cities_id: denver.id)
-      user.favorites.create(cities_id: golden.id)
+      user.favorites.create(city_id: denver.id)
+      user.favorites.create(city_id: golden.id)
 
       expect(user.favorites.count).to eq(2)
 
@@ -34,11 +34,11 @@ describe 'DELETE /api/v1/favorites' do
     it 'does not remove a city from the favorites, and a 401 code is returned' do
       user = create(:user, api_key: "abc123")
 
-      denver = Cities.find_or_create_city("denver,co")
-      golden = Cities.find_or_create_city("golden,co")
+      denver = City.find_or_create_city("denver,co")
+      golden = City.find_or_create_city("golden,co")
 
-      user.favorites.create(cities_id: denver.id)
-      user.favorites.create(cities_id: golden.id)
+      user.favorites.create(city_id: denver.id)
+      user.favorites.create(city_id: golden.id)
 
       expect(user.favorites.count).to eq(2)
 

--- a/spec/services/photo_service_spec.rb
+++ b/spec/services/photo_service_spec.rb
@@ -5,7 +5,7 @@ describe 'PhotoService', type: :service do
     context 'city_img' do
       it 'returns a URL for a background image based on search location' do
 
-        denver = Cities.create(
+        denver = City.create(
           { search_name: "denver,co",
             latitude: 39.7392,
             longitude: 104.9902,


### PR DESCRIPTION
Renames Cities model to City
Updates all references to City model.
Created a migration changing column name on Favorite Model from cities_id to city_id